### PR TITLE
Order tasks by enum status

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::TasksController < ApplicationController
   before_action :set_task, only: [ :show, :update, :destroy ]
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   def index
-    @tasks = Task.order(:status, :position)
+    @tasks = Task.ordered_by_status
     render json: @tasks
   end
   def show

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,6 +12,19 @@ class Task < ApplicationRecord
     done:        "done"
   }, default: :todo
 
+  # Order tasks by the logical status progression defined in the enum
+  # rather than the default alphabetical order of the status column.
+  scope :ordered_by_status, lambda {
+    order(
+      Arel.sql(
+        "CASE status " +
+          statuses.keys.map.with_index { |s, i| "WHEN '#{s}' THEN #{i}" }.join(" ") +
+          " END"
+      ),
+      :position
+    )
+  }
+
   before_validation :assign_position, on: :create
   before_update     :push_to_end_if_column_changed
   before_update     :reorder_within_same_status

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,7 +1,13 @@
 require "test_helper"
 
 class TaskTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "orders tasks by enum status and position" do
+    Task.delete_all
+
+    Task.create!(title: "done first", status: :done, position: 0)
+    Task.create!(title: "todo first", status: :todo, position: 0)
+    Task.create!(title: "in progress", status: :in_progress, position: 0)
+
+    assert_equal %w[todo in_progress done], Task.ordered_by_status.pluck(:status)
+  end
 end


### PR DESCRIPTION
## Summary
- ensure tasks are ordered by logical status rather than alphabetical sort
- expose ordered scope and update API index to use it
- add model test covering ordered scope

## Testing
- `bundle exec rake test` (fails: Could not find rails-8.0... in locally installed gems)
- `bundle exec rubocop` (fails: bundler: command not found: rubocop)


------
https://chatgpt.com/codex/tasks/task_e_68be827d355c8332b73f791cb435b059