### PR TITLE
Add ordered status scope and update task tests

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -8,9 +8,15 @@ class Task < ApplicationRecord
   # use "todo" here too.
   enum :status, {
     todo:        "todo",
-    in_progress: "in_progress",
-    done:        "done"
+    done:        "done",
+    in_progress: "in_progress"
   }, default: :todo
+
+  STATUS_ORDER_SQL = statuses.keys.each_with_index.map { |s, i| "WHEN '#{s}' THEN #{i}" }.join(' ').freeze
+
+  scope :order_by_status_and_position, -> {
+    order(Arel.sql("CASE status #{STATUS_ORDER_SQL} END"), :position)
+  }
 
   before_validation :assign_position, on: :create
   before_update     :adjust_positions_on_status_change

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,18 +1,28 @@
 require "test_helper"
 
 class TaskTest < ActiveSupport::TestCase
-  test "reorders positions when moving between statuses" do
-    a = Task.create!(title: "A", status: "todo")
-    b = Task.create!(title: "B", status: "todo")
-    c = Task.create!(title: "C", status: "todo")
-    d = Task.create!(title: "D", status: "done")
-    e = Task.create!(title: "E", status: "done")
+  test "orders tasks by enum status and position" do
+    Task.create!(title: "one first", status: :todo,        position: 0)
+    Task.create!(title: "two first", status: :in_progress, position: 0)
+    Task.create!(title: "one",       status: :todo,        position: 1)
+    Task.create!(title: "two",       status: :done,        position: 1)
 
-    b.update!(status: "done", position: 1)
+    assert_equal ["one first", "one", "two", "two first"],
+                 Task.order_by_status_and_position.pluck(:title)
+  end
+
+  test "reorders positions when moving between statuses" do
+    a = Task.create!(title: "A", status: :todo)
+    b = Task.create!(title: "B", status: :todo)
+    c = Task.create!(title: "C", status: :todo)
+    d = Task.create!(title: "D", status: :done)
+    e = Task.create!(title: "E", status: :done)
+
+    b.update!(status: :done, position: 1)
 
     assert_equal [[a.id, 0], [c.id, 1]],
-                 Task.where(status: "todo").order(:position).pluck(:id, :position)
+                 Task.where(status: :todo).order(:position).pluck(:id, :position)
     assert_equal [[d.id, 0], [b.id, 1], [e.id, 2]],
-                 Task.where(status: "done").order(:position).pluck(:id, :position)
+                 Task.where(status: :done).order(:position).pluck(:id, :position)
   end
 end


### PR DESCRIPTION
## Summary
- order tasks consistently by status and position
- cover task ordering and status reordering in tests

## Testing
- `bin/rubocop` *(fails: Could not find rails-8.0.2.1, propshaft-1.2.1, pg-1.6.1-x86_64-linux, puma-6.6.1, importmap-rails-2.2.2, turbo-rails-2.0.16, stimulus-rails-1.3.4, jbuilder-2.14.1, solid_cache-1.0.7, solid_queue-1.2.1, solid_cable-3.0.12, bootsnap-1.18.6, kamal-2.7.0, thruster-0.1.15-x86_64-linux, debug-1.11.0, brakeman-7.1.0, rubocop-rails-omakase-1.1.0, web-console-4.2.1, capybara-3.40.0, selenium-webdriver-4.35.0, vite_rails-3.0.19, rack-cors-3.0.0, actioncable-8.0.2.1, actionmailbox-8.0.2.1, actionmailer-8.0.2.1, actionpack-8.0.2.1, actiontext-8.0.2.1, actionview-8.0.2.1, activejob-8.0.2.1, activemodel-8.0.2.1, activerecord-8.0.2.1, activestorage-8.0.2.1, activesupport-8.0.2.1, railties-8.0.2.1, rack-3.2.0, nio4r-2.7.4, concurrent-ruby-1.3.5, fugit-1.11.2, thor-1.4.0, msgpack-1.8.0, base64-0.3.0, bcrypt_pbkdf-1.1.1, dotenv-3.1.8, ed25519-1.4.0, net-ssh-7.3.0, sshkit-1.24.0, zeitwerk-2.7.3, irb-1.15.2, reline-0.6.2, racc-1.8.1, rubocop-1.80.1, rubocop-performance-1.25.0, rubocop-rails-2.33.3, bindex-0.8.1, addressable-2.8.7, matrix-0.4.3, mini_mime-1.1.5, nokogiri-1.18.9-x86_64-linux-gnu, rack-test-2.2.0, regexp_parser-2.11.2, xpath-3.2.0, logger-1.7.0, rexml-3.4.2, rubyzip-3.0.2, websocket-1.2.11, vite_ruby-3.9.2, websocket-driver-0.8.0, mail-2.8.1, rails-dom-testing-2.3.0, rack-session-2.1.1, rails-html-sanitizer-1.6.2, useragent-0.16.11, globalid-1.2.1, builder-3.3.0, erubi-1.13.1, timeout-0.4.3, marcel-1.0.4, benchmark-0.4.1, bigdecimal-3.2.2, connection_pool-2.5.4, drb-2.2.3, i18n-1.14.7, minitest-5.25.5, securerandom-0.4.1, tzinfo-2.0.6, uri-1.0.3, rackup-2.2.1, rake-13.3.0, et-orbi-1.3.0, raabro-1.4.0, net-scp-4.1.0, net-sftp-4.0.0, ostruct-0.6.3, pp-0.6.2, rdoc-6.14.2, io-console-0.8.1, json-2.13.2, language_server-protocol-3.17.0.5, lint_roller-1.1.0, parallel-1.27.0, parser-3.3.9.0, rainbow-3.1.1, rubocop-ast-1.46.0, ruby-progressbar-1.13.0, unicode-display_width-3.1.5, public_suffix-6.0.2, dry-cli-1.3.0, mutex_m-0.3.0, rack-proxy-0.7.7, websocket-extensions-0.1.5, net-imap-0.5.10, net-smtp-0.5.1, loofah-2.24.1, prettyprint-0.2.0, erb-5.0.2, psych-5.2.6, ast-2.4.3, prism-1.4.0, unicode-emoji-4.0.4, date-3.4.1, net-protocol-0.2.2, crass-1.0.6, stringio-3.1.7 in locally installed gems (Bundler::GemNotFound)`
- `bin/rails test` *(fails: Could not find rails-8.0.2.1, propshaft-1.2.1, pg-1.6.1-x86_64-linux, puma-6.6.1, importmap-rails-2.2.2, turbo-rails-2.0.16, stimulus-rails-1.3.4, jbuilder-2.14.1, solid_cache-1.0.7, solid_queue-1.2.1, solid_cable-3.0.12, bootsnap-1.18.6, kamal-2.7.0, thruster-0.1.15-x86_64-linux, debug-1.11.0, brakeman-7.1.0, rubocop-rails-omakase-1.1.0, web-console-4.2.1, capybara-3.40.0, selenium-webdriver-4.35.0, vite_rails-3.0.19, rack-cors-3.0.0, actioncable-8.0.2.1, actionmailbox-8.0.2.1, actionmailer-8.0.2.1, actionpack-8.0.2.1, actiontext-8.0.2.1, actionview-8.0.2.1, activejob-8.0.2.1, activemodel-8.0.2.1, activerecord-8.0.2.1, activestorage-8.0.2.1, activesupport-8.0.2.1, railties-8.0.2.1, rack-3.2.0, nio4r-2.7.4, concurrent-ruby-1.3.5, fugit-1.11.2, thor-1.4.0, msgpack-1.8.0, base64-0.3.0, bcrypt_pbkdf-1.1.1, dotenv-3.1.8, ed25519-1.4.0, net-ssh-7.3.0, sshkit-1.24.0, zeitwerk-2.7.3, irb-1.15.2, reline-0.6.2, racc-1.8.1, rubocop-1.80.1, rubocop-performance-1.25.0, rubocop-rails-2.33.3, bindex-0.8.1, addressable-2.8.7, matrix-0.4.3, mini_mime-1.1.5, nokogiri-1.18.9-x86_64-linux-gnu, rack-test-2.2.0, regexp_parser-2.11.2, xpath-3.2.0, logger-1.7.0, rexml-3.4.2, rubyzip-3.0.2, websocket-1.2.11, vite_ruby-3.9.2, websocket-driver-0.8.0, mail-2.8.1, rails-dom-testing-2.3.0, rack-session-2.1.1, rails-html-sanitizer-1.6.2, useragent-0.16.11, globalid-1.2.1, builder-3.3.0, erubi-1.13.1, timeout-0.4.3, marcel-1.0.4, benchmark-0.4.1, bigdecimal-3.2.2, connection_pool-2.5.4, drb-2.2.3, i18n-1.14.7, minitest-5.25.5, securerandom-0.4.1, tzinfo-2.0.6, uri-1.0.3, rackup-2.2.1, rake-13.3.0, et-orbi-1.3.0, raabro-1.4.0, net-scp-4.1.0, net-sftp-4.0.0, ostruct-0.6.3, pp-0.6.2, rdoc-6.14.2, io-console-0.8.1, json-2.13.2, language_server-protocol-3.17.0.5, lint_roller-1.1.0, parallel-1.27.0, parser-3.3.9.0, rainbow-3.1.1, rubocop-ast-1.46.0, ruby-progressbar-1.13.0, unicode-display_width-3.1.5, public_suffix-6.0.2, dry-cli-1.3.0, mutex_m-0.3.0, rack-proxy-0.7.7, websocket-extensions-0.1.5, net-imap-0.5.10, net-smtp-0.5.1, loofah-2.24.1, prettyprint-0.2.0, erb-5.0.2, psych-5.2.6, ast-2.4.3, prism-1.4.0, unicode-emoji-4.0.4, date-3.4.1, net-protocol-0.2.2, crass-1.0.6, stringio-3.1.7 in locally installed gems (Bundler::GemNotFound)`


------
https://chatgpt.com/codex/tasks/task_e_68be8624ff248332acf46c393f22cd32