### PR TITLE
Allow inserting tasks at specific position

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -28,9 +28,17 @@ class Task < ApplicationRecord
   private
 
   def assign_position
-    return unless position.nil?
-    # ✅ use the setter
-    self.position = (Task.where(status: status).maximum(:position) || -1) + 1
+    max_pos = Task.where(status: status).maximum(:position) || -1
+
+    if position.nil? || position > max_pos + 1
+      # place at the end if no position supplied or out of range
+      self.position = max_pos + 1
+    else
+      # make room for the new task
+      Task.where(status: status)
+          .where("position >= ?", position)
+          .update_all("position = position + 1")
+    end
   end
 
   def adjust_positions_on_status_change

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -25,4 +25,25 @@ class TaskTest < ActiveSupport::TestCase
     assert_equal [[d.id, 0], [b.id, 1], [e.id, 2]],
                  Task.where(status: :done).order(:position).pluck(:id, :position)
   end
+
+  test "moves task within same status" do
+    a = Task.create!(title: "A", status: :todo)
+    b = Task.create!(title: "B", status: :todo)
+    c = Task.create!(title: "C", status: :todo)
+
+    c.update!(position: 1)
+
+    assert_equal [[a.id, 0], [c.id, 1], [b.id, 2]],
+                 Task.where(status: :todo).order(:position).pluck(:id, :position)
+  end
+
+  test "inserts task at given position on create" do
+    a = Task.create!(title: "A", status: :todo)
+    b = Task.create!(title: "B", status: :todo)
+
+    d = Task.create!(title: "D", status: :todo, position: 1)
+
+    assert_equal [[a.id, 0], [d.id, 1], [b.id, 2]],
+                 Task.where(status: :todo).order(:position).pluck(:id, :position)
+  end
 end


### PR DESCRIPTION
## Summary
- shift existing tasks when assigning a new task to an explicit position
- cover reordering scenarios with new model tests

## Testing
- `bundle install` (fails: Net::HTTPClientException 403 "Forbidden")
- `bundle exec rails test` (fails: bundler: command not found: rails)

------
https://chatgpt.com/codex/tasks/task_e_68be87d5bbc08332a8e55e62b3ccb6f7