### PR TITLE
Fix drag leave handling to allow reordering tasks

### DIFF
--- a/app/frontend/TasksApp.jsx
+++ b/app/frontend/TasksApp.jsx
@@ -137,7 +137,8 @@ export default function TasksApp() {
     setHoverIndex(idx);                // remember which index we’re over
   }
 
-  function handleDragLeave() {
+  function handleDragLeave(e) {
+    if (e.currentTarget.contains(e.relatedTarget)) return;
     setHoverCol(null);
     setHoverIndex(null);
   }


### PR DESCRIPTION
## Summary
- avoid clearing drag hover state when moving within a column by checking `relatedTarget`

## Testing
- `bin/rails test` *(fails: Could not find rails-8.0.2.1 ...)*

------
https://chatgpt.com/codex/tasks/task_e_68be88fcd9148332b82c030cb4be6e38